### PR TITLE
Open Files or Directories in RIDE with right-click from Files panel (…

### DIFF
--- a/src/robotide/ui/mainframe.py
+++ b/src/robotide/ui/mainframe.py
@@ -175,7 +175,9 @@ class RideFrame(with_metaclass(classmaker(), wx.Frame, RideEventHandler)):
         self.Bind(wx.EVT_SIZE, self.OnSize)
         self.Bind(wx.EVT_MOVE, self.OnMove)
         self.Bind(wx.EVT_MAXIMIZE, self.OnMaximize)
-        self.Bind(wx.EVT_DIRCTRL_FILEACTIVATED, self.OnOpenFile)
+        if wx.VERSION >= (2, 9, 5, ''):  # DEBUG wxPhoenix
+            self.Bind(wx.EVT_DIRCTRL_FILEACTIVATED, self.OnOpenFile)
+            self.Bind(wx.EVT_TREE_ITEM_RIGHT_CLICK, self.OnMenuOpenFile)
         self._subscribe_messages()
         #print("DEBUG: Call register_tools, actions: %s" % self.actions.__repr__())
         if PY2:
@@ -281,13 +283,15 @@ class RideFrame(with_metaclass(classmaker(), wx.Frame, RideEventHandler)):
         self.actions.register_actions(
             ActionInfoCollection(_menudata, self, self.tree))
         ###### File explorer pane
-        self.filemgr = wx.GenericDirCtrl(self, -1, size=(200, 225),
-                                         style=wx.DIRCTRL_3D_INTERNAL)
-        self.filemgr.SetMinSize(wx.Size(120, 200))
-        self._mgr.AddPane(self.filemgr,
-                          aui.AuiPaneInfo().Name("file_manager").
-                          Caption("Files").LeftDockable(True).
-                          CloseButton(True))
+        if wx.VERSION >= (2, 9, 5, ''):  # DEBUG wxPhoenix
+            self.filemgr = wx.GenericDirCtrl(self, -1, size=(200, 225),
+                                             style=wx.DIRCTRL_3D_INTERNAL)
+            self.filemgr.SetMinSize(wx.Size(120, 200))
+            # wx.CallAfter(self.filemgr.SetPath(self.tree.get_selected_datafile()))
+            self._mgr.AddPane(self.filemgr,
+                              aui.AuiPaneInfo().Name("file_manager").
+                              Caption("Files").LeftDockable(True).
+                              CloseButton(True))
 
         mb.take_menu_bar_into_use()
         #### self.splitter.SetMinimumPaneSize(100)
@@ -428,6 +432,8 @@ class RideFrame(with_metaclass(classmaker(), wx.Frame, RideEventHandler)):
             self.filemgr.Update()
 
     def OnOpenFile(self, event):
+        if not self.filemgr:
+            return
         # EVT_DIRCTRL_FILEACTIVATED
         from os.path import splitext
         robottypes = self._application.settings.get('robot types', ['robot',
@@ -436,19 +442,32 @@ class RideFrame(with_metaclass(classmaker(), wx.Frame, RideEventHandler)):
                                                                     'tsv',
                                                                     'html'])
         path = self.filemgr.GetFilePath()
-        ext = splitext(path)
-        ext = ext[1].replace('.', '')
-        # print("DEBUG: path %s ext %s" % (path, ext))
-        if ext in robottypes:
+        ext = ''
+        if len(path) > 0:
+            ext = splitext(path)
+            ext = ext[1].replace('.', '')
+            # print("DEBUG: path %s ext %s" % (path, ext))
+        if len(ext) > 0 and ext in robottypes:
             if not self.check_unsaved_modifications():
                 return
-            try:
-                self.open_suite(path)
+            if self.open_suite(path):
                 return
-            except UserWarning as e:
-                pass
         from robotide.editor import customsourceeditor
         customsourceeditor.main(path)
+
+    def OnMenuOpenFile(self, event):
+        if not self.filemgr:
+            return
+        # TODO: Use widgets/popupmenu tools
+        path = self.filemgr.GetFilePath()
+        if len(path) > 0:
+            self.OnOpenFile(event)
+        else:
+            path = self.filemgr.GetPath()
+            if not self.check_unsaved_modifications():
+                return
+            self.open_suite(path)  # It is a directory, do not edit
+        event.Skip()
 
     def OnOpenTestSuite(self, event):
         if not self.check_unsaved_modifications():
@@ -456,11 +475,8 @@ class RideFrame(with_metaclass(classmaker(), wx.Frame, RideEventHandler)):
         path = RobotFilePathDialog(
             self, self._controller, self._application.settings).execute()
         if path:
-            try:
-                self.open_suite(path)
+            if self.open_suite(path):
                 return
-            except UserWarning as e:
-                pass
             from robotide.editor import customsourceeditor
             customsourceeditor.main(path)
 
@@ -474,13 +490,19 @@ class RideFrame(with_metaclass(classmaker(), wx.Frame, RideEventHandler)):
 
     def open_suite(self, path):
         self._controller.update_default_dir(path)
-        err = self._controller.load_datafile(path, LoadProgressObserver(self))
-        if isinstance(err, UserWarning):
-            raise err
+        try:
+            err = self._controller.load_datafile(path, LoadProgressObserver(self))
+        finally:
+            if isinstance(err, UserWarning):
+                # raise err  # Just leave message in Parser Log
+                return False
         self._populate_tree()
+        return True
 
     def refresh_datafile(self, item, event):
         self.tree.refresh_datafile(item, event)
+        if self.filemgr:
+            self.filemgr.ReCreateTree()
 
     def OnOpenDirectory(self, event):
         if self.check_unsaved_modifications():

--- a/test_all.sh
+++ b/test_all.sh
@@ -13,7 +13,7 @@ then
          PY=2.7
     elif [ $1 -eq 3 ]
     then
-         PY=3.6
+         PY=3.7
     else
         DIR="$1"
     fi


### PR DESCRIPTION
…#1980)

* New Parser Log tab to avoid dialog when loading Test Suite

* Correct Copyright year

* Now we can open directories or files with a single-click on File Explorer

* python 3.7

* Now we can open directories or files with right-click (double-click for files too)  on File Explorer